### PR TITLE
add slack alert with NCF GitHub Trigger sample code

### DIFF
--- a/samples/nodejs/slack/index.js
+++ b/samples/nodejs/slack/index.js
@@ -1,0 +1,28 @@
+const axios = require('axios');
+
+function alertSlack(params) {
+  const repoName = params.repository.name;
+  const commitInfo = params.commits[0];
+  const author = commitInfo.author.name;
+  const commitMsg = commitInfo.message;
+
+  const alertData = {
+    text: `user(${author}) commited on repo(${repoName}) with msg(${commitMsg})`,
+  };
+
+  return new Promise(function (resolve, reject) {
+    axios
+      .post(params.slackUrl, alertData)
+      .then(() => {
+        resolve({ done: true });
+      })
+      .catch((error) => {
+        reject({
+          done: false,
+          errorMessage: error, // or error.response.data.message
+        });
+      });
+  });
+}
+
+exports.main = alertSlack;

--- a/samples/nodejs/slack/package.json
+++ b/samples/nodejs/slack/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "slack",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "lint": "eslint index.js --fix"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "axios": "^0.27.2"
+  },
+  "devDependencies": {
+    "eslint": "^8.15.0",
+    "eslint-config-prettier": "^8.5.0",
+    "eslint-plugin-prettier": "^4.0.0",
+    "prettier": "^2.6.2"
+  }
+}


### PR DESCRIPTION
+ NCF GitHub Trigger를 활용하여, 특정 레포에 발생한 커밋 이력 및 정보를 Slack으로 전송하는 샘플 액션