### PR TITLE
Fix: Exception logging & Python 3.11 compatibility

### DIFF
--- a/samples/python/mongodb/__main__.py
+++ b/samples/python/mongodb/__main__.py
@@ -24,4 +24,4 @@ def main(args):
         return {"done": True}
 
     except Exception as e:
-        return {"done": False, "error_message": e}
+        return {"done": False, "error_message": str(e)}

--- a/samples/python/object-storage/bucket/create-bucket/__main__.py
+++ b/samples/python/object-storage/bucket/create-bucket/__main__.py
@@ -29,4 +29,4 @@ def main(args):
         return {"done": True}
 
     except Exception as e:
-        return {"done": False, "error_message": e}
+        return {"done": False, "error_message": str(e)}

--- a/samples/python/object-storage/bucket/delete-bucket/__main__.py
+++ b/samples/python/object-storage/bucket/delete-bucket/__main__.py
@@ -29,4 +29,4 @@ def main(args):
         return {"done": True}
 
     except Exception as e:
-        return {"done": False, "error_message": e}
+        return {"done": False, "error_message": str(e)}

--- a/samples/python/object-storage/bucket/list-bucket/__main__.py
+++ b/samples/python/object-storage/bucket/list-bucket/__main__.py
@@ -1,3 +1,4 @@
+import platform
 import boto3
 
 service_name = "s3"
@@ -16,6 +17,11 @@ args:
 
 def main(args):
     try:
+        major, minor, path = platform.python_version_tuple()
+        if major == "3" and minor == "11":
+            import collections
+            collections.Callable = collections.abc.Callable
+        
         s3 = boto3.client(
             service_name,
             endpoint_url=endpoint,
@@ -24,8 +30,10 @@ def main(args):
         )
 
         buckets = s3.list_buckets()
+        
+        bucket_names = [bucket["Name"] for bucket in buckets.get("Buckets", [])]
 
-        return {"done": True, "buckets": buckets}
+        return {"done": True, "buckets": bucket_names}
 
     except Exception as e:
-        return {"done": False, "error_message": e}
+        return {"done": False, "error_message": str(e)}

--- a/samples/python/object-storage/object/delete-object/__main__.py
+++ b/samples/python/object-storage/object/delete-object/__main__.py
@@ -30,4 +30,4 @@ def main(args):
         return {"done": True}
 
     except Exception as e:
-        return {"done": False, "error_message": e}
+        return {"done": False, "error_message": str(e)}

--- a/samples/python/object-storage/object/list-object/__main__.py
+++ b/samples/python/object-storage/object/list-object/__main__.py
@@ -1,3 +1,4 @@
+import platform
 import boto3
 
 service_name = "s3"
@@ -18,6 +19,11 @@ args:
 
 def main(args):
     try:
+        major, minor, path = platform.python_version_tuple()
+        if major == "3" and minor == "11":
+            import collections
+            collections.Callable = collections.abc.Callable
+            
         s3 = boto3.client(
             service_name,
             endpoint_url=endpoint,
@@ -39,4 +45,4 @@ def main(args):
         return {"done": True, "objects": object_list}
 
     except Exception as e:
-        return {"done": False, "error_message": e}
+        return {"done": False, "error_message": str(e)}

--- a/samples/python/object-storage/object/upload-object/__main__.py
+++ b/samples/python/object-storage/object/upload-object/__main__.py
@@ -30,5 +30,5 @@ def main(args):
         return {"done": True}
 
     except Exception as e:
-        return {"done": False, "error_message": e}
+        return {"done": False, "error_message": str(e)}
 


### PR DESCRIPTION
### 변경 사항
1. **예외 메시지 변환 개선** (`e -> str(e)`)
   - 예외 메시지를 직렬화할 때 `str(e)`로 변환하여 JSON 직렬화 오류를 방지함.

2. **Python 3.11 호환성 수정**
   - `collections.Callable`이 Python 3.11에서 제거됨.
   - `collections.abc.Callable`로 변경하여 최신 Python 버전에서도 정상 동작하도록 수정.